### PR TITLE
Refactor Long Method

### DIFF
--- a/HtmlCleaner.cs
+++ b/HtmlCleaner.cs
@@ -15,62 +15,79 @@ namespace MultiParser
 
             try
             {
-                html = html.Trim();
+                string[] parts = HtmlToParts(html);
 
-                if (!html.StartsWith("<"))
-                    html = "<" + html;
-
-                int closingTagIndex = html.IndexOf('>');
-                if (closingTagIndex == -1)
-                    closingTagIndex = html.Length;
-
-                string tagContent = html.Substring(1, closingTagIndex - 1).Trim();
-
-                string[] parts = tagContent.Split(new[] { ' ' }, 2, StringSplitOptions.RemoveEmptyEntries);
                 string tagName = parts[0];
                 string attributesPart = parts.Length > 1 ? parts[1] : "";
-
                 string id = "";
                 List<string> classes = new List<string>();
 
                 if (!string.IsNullOrEmpty(attributesPart))
                 {
-                    var attrs = attributesPart.Split(new[] { '\"' }, StringSplitOptions.RemoveEmptyEntries);
-                    for (int i = 0; i < attrs.Length - 1; i += 2)
-                    {
-                        string attrName = attrs[i].Trim(' ', '=');
-                        string attrValue = attrs[i + 1];
-
-                        if (attrName.Equals("class", StringComparison.OrdinalIgnoreCase))
-                        {
-                            classes.AddRange(attrValue.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
-                        }
-                        else if (attrName.Equals("id", StringComparison.OrdinalIgnoreCase))
-                        {
-                            id = attrValue;
-                        }
-                    }
+                    id = ParseAttributesPart(attributesPart, classes);
                 }
 
-                StringBuilder selector = new StringBuilder();
-                selector.Append(tagName);
-
-                if (!string.IsNullOrEmpty(id))
-                {
-                    selector.Append("#" + id);
-                }
-
-                foreach (var cls in classes)
-                {
-                    selector.Append("." + cls);
-                }
-
-                return selector.ToString();
+                return BuildTag(tagName, id, classes);
             }
             catch
             {
                 return "";
             }
+        }
+
+        private static string BuildTag(string tagName, string id, List<string> classes)
+        {
+            StringBuilder selector = new StringBuilder();
+            selector.Append(tagName);
+
+            if (!string.IsNullOrEmpty(id))
+            {
+                selector.Append("#" + id);
+            }
+
+            foreach (var cls in classes)
+            {
+                selector.Append("." + cls);
+            }
+
+            return selector.ToString();
+        }
+
+        private static string ParseAttributesPart(string attributesPart, List<string> classes)
+        {
+            string id = "";
+            var attrs = attributesPart.Split(new[] { '\"' }, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < attrs.Length - 1; i += 2)
+            {
+                string attrName = attrs[i].Trim(' ', '=');
+                string attrValue = attrs[i + 1];
+
+                if (attrName.Equals("class", StringComparison.OrdinalIgnoreCase))
+                {
+                    classes.AddRange(attrValue.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
+                }
+                else if (attrName.Equals("id", StringComparison.OrdinalIgnoreCase))
+                {
+                    id = attrValue;
+                }
+            }
+            return id;
+        }
+
+        private static string[] HtmlToParts(string html)
+        {
+            html = html.Trim();
+
+            if (!html.StartsWith("<"))
+                html = "<" + html;
+
+            int closingTagIndex = html.IndexOf('>');
+            if (closingTagIndex == -1)
+                closingTagIndex = html.Length;
+
+            string tagContent = html.Substring(1, closingTagIndex - 1).Trim();
+
+            return tagContent.Split(new[] { ' ' }, 2, StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }


### PR DESCRIPTION
This PR remove code smell Long Method from HtmlCleaner class.

#### Changes
* Methods CleanHtmlToSelector was too long, so I extract 3 methods from it - HtmlToParts, ParseAttributesPart, BuildTag.

#### Benefits
* Eliminating the code smell Long Method, ease of method maintenance, made self-commenting methods